### PR TITLE
Added keybind for emote

### DIFF
--- a/gremlin.py
+++ b/gremlin.py
@@ -526,6 +526,10 @@ class GremlinWindow(QWidget):
 
         self.movement_handler.recordKeyPress(event)
 
+        if self.movement_handler.is_emotekey_pressed():
+            self.set_state(State.EMOTE)
+            self.reset_emote_timer()
+
         if self.movement_handler.is_moving():
             self.set_state(State.WALK)
             self.reset_idle_timer()

--- a/movement_handler.py
+++ b/movement_handler.py
@@ -15,6 +15,7 @@ class MovementHandler:
         self.a = False
         self.s = False
         self.d = False
+        self.p = False
         self.v = settings.Settings.MoveSpeed
 
     def getVelocity(self) -> tuple[int, int]:
@@ -47,6 +48,9 @@ class MovementHandler:
         if self.a ^ self.d:
             horizontal = "Left" if self.a else "Right"
         return vertical + horizontal
+    
+    def is_emotekey_pressed(self) -> bool:
+        return self.p
 
     # --- @! event recorders -------------------------------------------------------------
 
@@ -61,6 +65,8 @@ class MovementHandler:
                 self.s = True
             case Qt.Key.Key_D:
                 self.d = True
+            case Qt.Key.Key_P:
+                self.p = True
 
     def recordKeyRelease(self, event):
         key = event.key()
@@ -73,9 +79,12 @@ class MovementHandler:
                 self.s = False
             case Qt.Key.Key_D:
                 self.d = False
+            case Qt.Key.Key_P:
+                self.p = False
 
     def recordMouseLeave(self):
         self.w = False
         self.a = False
         self.s = False
         self.d = False
+        self.p = False


### PR DESCRIPTION
I wanted to add a keybind to show off Mambo's emote animation whenever I liked (because it's fun), and I bound it to the "P" key for the moment. 

In the subsequent commits, I will try to add a way to run the program in a sort of "emote-key" mode by appending a flag to the script, so a future user doesn't necessarily have to stumble across what it is possibly a "surprise" feature