### PR TITLE
Correct shebang to reflect use of bash built-in `disown'

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Launcher for Linux Desktop Gremlins
 USE_UV=1
 USE_VENV=0


### PR DESCRIPTION
\``disown`' is a bashism but the shebang in `run.sh` was originally "`#!/bin/sh`", which causes the `disown` line to fail anytime `/bin/sh` points to a shell which doesn't have the `disown` bulitin. This PR simply corrects the shebang to point explicitly to Bash.