### PR TITLE
feat: Packaging for NixOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,117 @@
+{
+  lib,
+  python3Packages,
+  makeDesktopItem,
+  copyDesktopItems,
+  qt6,
+  xorg,
+  pipewire,
+  wrapGAppsHook3,
+  jq,
+  python3,
+  bash,
+  rofi,
+  libxcb,
+  libxcb-cursor,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxcb-image,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "linux-desktop-gremlin";
+  version = "0-unstable-2025-12-11";
+
+  src = ./.;
+
+  pyproject = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "linux-desktop-gremlin";
+      desktopName = "Linux Desktop Gremlin";
+      icon = "linux-desktop-gremlin";
+      exec = "linux-desktop-gremlin";
+      comment = "Pick your favorite gremlin";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    python3Packages.setuptools
+    python3Packages.wheel
+    wrapGAppsHook3
+    qt6.wrapQtAppsHook
+    jq
+  ];
+
+  propagatedBuildInputs =
+    with python3Packages;
+    [
+      pyside6
+      qt6.qtbase
+      qt6.qtwayland
+      pipewire
+    ]
+    ++ (with xorg; [
+      libX11
+      libXcursor
+      libXrandr
+      libXi
+      libXrender
+      libXext
+    ])
+    ++ [
+      libxcb
+      libxcb-cursor
+      libxcb-keysyms
+      libxcb-render-util
+      libxcb-image
+    ];
+
+  postInstall = ''
+    mkdir -p $out/share/linux-desktop-gremlin/{src,scripts}
+    cp -r $src/src/* $out/share/linux-desktop-gremlin/src/
+    cp -r $src/spritesheet $out/share/linux-desktop-gremlin/spritesheet
+    cp -r $src/sounds $out/share/linux-desktop-gremlin/sounds
+
+    install -Dm644 $src/config.json $out/share/linux-desktop-gremlin/config.json
+    jq '.Systray = true' $src/config.json > $out/share/linux-desktop-gremlin/config.json # enable tray
+
+    install -Dm755 $src/scripts/gremlin-picker.sh $out/share/linux-desktop-gremlin/scripts/gremlin-picker.sh
+    sed -i "s|./run.sh \"\$pick\"|$out/bin/linux-desktop-gremlin \"\$pick\"|" \
+      $out/share/linux-desktop-gremlin/scripts/gremlin-picker.sh
+
+    install -Dm644 $src/icon.png $out/share/icons/hicolor/256x256/apps/linux-desktop-gremlin.png
+  '';
+
+  postFixup =
+    let
+      binPath = lib.makeBinPath [
+        python3
+        bash
+        rofi
+      ];
+    in
+    ''
+      wrapProgram $out/bin/linux-desktop-gremlin \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PYTHONPATH : $out/share/linux-desktop-gremlin \
+        --set QT_QPA_PLATFORM xcb \
+        --prefix LD_LIBRARY_PATH : ${pipewire}/lib \
+        --prefix PATH : ${binPath}
+      makeWrapper $out/share/linux-desktop-gremlin/scripts/gremlin-picker.sh $out/bin/gremlin-picker \
+        --prefix PYTHONPATH : $out/share/linux-desktop-gremlin \
+        --prefix PATH : ${binPath}
+    '';
+
+  meta = {
+    description = "Linux Desktop Gremlins brings animated mascots to your Linux desktop.";
+    homepage = "https://github.com/iluvgirlswithglasses/linux-desktop-gremlin";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "linux-desktop-gremlin";
+    maintainers = with lib.maintainers; [ lonerOrz ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Linux Desktop Gremlins brings animated mascots to your Linux desktop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems =
+        f:
+        builtins.listToAttrs (
+          map (system: {
+            name = system;
+            value = f system;
+          }) supportedSystems
+        );
+
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          linux-desktop-gremlin = pkgs.callPackage ./default.nix { };
+          default = self.packages.${system}.linux-desktop-gremlin;
+        }
+      );
+    };
+}


### PR DESCRIPTION
Nixos users install

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    gremlin.url = "github:iluvgirlswithglasses/linux-desktop-gremlin";
  };

  outputs =
    inputs@{
      self,
      flake-utils,
      nixpkgs,
      ...
    }:
    flake-utils.lib.eachDefaultSystem (
      system:
      let
        pkgs = import nixpkgs {
          inherit system;
        };
      in
      {
        devShells.default = pkgs.mkShell {
          packages = [ inputs.gremlin.packages.${system}.linux-desktop-gremlin ];
        };
      }
    );
}
```