### PR TITLE
bug: fixed audio issues while in outro state

### DIFF
--- a/src/gremlin.py
+++ b/src/gremlin.py
@@ -408,6 +408,9 @@ class GremlinWindow(QWidget):
         if settings.Settings.Systray:
             self.tray_icon.hide()
 
+        # correctly sets the outro state to fix some audio issues
+        self.set_state(State.OUTRO)
+
         # here should be played the outro sound
         self.play_sound(settings.SfxMap.Outro)
 
@@ -495,8 +498,8 @@ class GremlinWindow(QWidget):
     # --- @! Event Handlers (Mouse) ------------------------------------------------------
 
     def mousePressEvent(self, event):
-        # Temporarily disable mouse press when emoting...
-        if self.current_state == State.EMOTE:
+        # Temporarily disable mouse press when emoting and while the character is playing the outro
+        if self.current_state in [State.EMOTE, State.OUTRO]:
             return
 
         # ...otherwise, reset the idle timer. Since a click event is an interaction of
@@ -560,7 +563,7 @@ class GremlinWindow(QWidget):
         if self.current_state == State.IDLE:
             self.set_state(State.HOVER)
 
-        if self.current_state not in [State.WALK, State.GRAB, State.SLEEP, State.POKE, State.EMOTE]:
+        if self.current_state not in [State.WALK, State.GRAB, State.SLEEP, State.POKE, State.EMOTE, State.OUTRO]:
             self.play_sound(settings.SfxMap.Hover, 3)
 
     def leaveEvent(self, event):


### PR DESCRIPTION
Problem: some of the new characters that have an outro playback, including Haru Urara (which I tested with), while closing their window would still accept commands like pats or hovering and play the respective sounds, causing some mild annoyances which just sound out of place
Fix: I modified the mousePressEvent call and the enterEvent call to account for the State.OUTRO state, which was implemented, but for some reason never used.

This should fix any audio bugs regarding outro animations.
I'm open to additional replies regarding this, but it should be a straightforward fix nontheless