### PR TITLE
fixed weird texture atlas bug in pat anim

### DIFF
--- a/spritesheet/haru-urara/frame-count.json
+++ b/spritesheet/haru-urara/frame-count.json
@@ -15,7 +15,7 @@
     "DownRight": 18,
     "WalkIdle": 40,
     "Poke": 73,
-    "Pat": 50,
+    "Pat": 40,
     "LeftAction": 0,
     "RightAction": 0,
     "Reload": 0,


### PR DESCRIPTION
The original texture atlas had 50 frames, while the one updated by the other contributor had 40 frames. It was a simple fix by just changing the values in the frame-count.json 