### PR TITLE
Add "Download All" button in the Gremlin Downloader GUI

### DIFF
--- a/src/asset_downloader_gui.py
+++ b/src/asset_downloader_gui.py
@@ -98,7 +98,13 @@ class AssetDownloaderGui(QDialog):
             "background-color: #528bff; color: white; border: none; padding: 8px 16px; border-radius: 4px;"
         )
 
+        self.download_all_btn = QPushButton("Download All")
+        self.download_all_btn.setStyleSheet(
+            "background-color: #2e7d32; color: white; border: none; padding: 8px 16px; border-radius: 4px;"
+        )
+
         btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.download_all_btn)
         btn_layout.addStretch()
         btn_layout.addWidget(self.delete_btn)
         btn_layout.addWidget(self.close_btn)

--- a/src/asset_downloader_gui.py
+++ b/src/asset_downloader_gui.py
@@ -72,7 +72,7 @@ class AssetDownloaderGui(QDialog):
 
         # Queue for the multiple gremlin downloads
         self.download_queue = []
-        self.active_worker = None
+        self.active_worker: DownloadWorker | None = None
 
         self.init_ui()
 
@@ -173,9 +173,9 @@ class AssetDownloaderGui(QDialog):
             return
 
         self._to_download_state(name)
-        self.worker = DownloadWorker(name, url)
-        self.worker.finished.connect(self.on_worker_finished)
-        self.worker.start()
+        self.active_worker = DownloadWorker(name, url)
+        self.active_worker.finished.connect(self.on_worker_finished)
+        self.active_worker.start()
     
     def download_all(self):
         downloadable_items = [

--- a/src/asset_downloader_gui.py
+++ b/src/asset_downloader_gui.py
@@ -70,6 +70,10 @@ class AssetDownloaderGui(QDialog):
         self.assets_data = load_asset_list()
         self.data_bucket = 69420  # unique role for storing data in QListWidgetItem
 
+        # Queue for the multiple gremlin downloads
+        self.download_queue = []
+        self.active_worker = None
+
         self.init_ui()
 
     def init_ui(self):
@@ -99,6 +103,7 @@ class AssetDownloaderGui(QDialog):
         )
 
         self.download_all_btn = QPushButton("Download All")
+        self.download_all_btn.clicked.connect(self.download_all)
         self.download_all_btn.setStyleSheet(
             "background-color: #2e7d32; color: white; border: none; padding: 8px 16px; border-radius: 4px;"
         )
@@ -169,18 +174,68 @@ class AssetDownloaderGui(QDialog):
 
         self._to_download_state(name)
         self.worker = DownloadWorker(name, url)
-        self.worker.finished.connect(self.on_finished)
+        self.worker.finished.connect(self.on_worker_finished)
         self.worker.start()
+    
+    def download_all(self):
+        downloadable_items = [
+            item for item in self.assets_data.items() 
+            if not self.is_installed(item[0])
+        ]
 
-    def on_finished(self, success: bool, message: str):
-        self._to_standby_state()
+        if not downloadable_items:
+            QMessageBox.information(
+                self,
+                "Everyone is here!",
+                "All gremlins are already installed."
+            )
+            return
+
+        warning_box = QMessageBox.question(
+            self,
+            "Confirm Download",
+            f"This will download the {len(downloadable_items)} gremlins that are not yet installed. Are you sure?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+
+        if warning_box != QMessageBox.StandardButton.Yes:
+            return
+        
+        self.download_queue = downloadable_items.copy()
+        self._to_download_all_state()
+        self.start_next_download()
+    
+    def start_next_download(self):        
+        item = self.download_queue.pop(0)
+        name, url = item
+
+        self.active_worker = DownloadWorker(name, url)
+        self.active_worker.finished.connect(self.on_worker_finished)
+        self.active_worker.start()
+
+    def _handle_single_finished(self, success: bool, message: str):
         if success:
             self.refresh_list()
         else:
             QMessageBox.critical(self, "Error", f"Failed to download: {message}")
+        
+    def on_worker_finished(self, success: bool, message: str):
+        # We have to refresh the list after every download
+        self._handle_single_finished(success, message)
+
+        if self.download_queue:
+            self.start_next_download()
+        else:
+            self._to_standby_state()    # Re-enables gremlin list
+            self.active_worker = None
 
     def _to_download_state(self, asset_name: str):
         self.info_label.setText(f"Downloading {asset_name}...")
+        self.list_widget.setEnabled(False)
+
+    def _to_download_all_state(self):
+        self.info_label.setText(f"Downloading all gremlins...")
         self.list_widget.setEnabled(False)
 
     def _to_standby_state(self):


### PR DESCRIPTION
### Description

Adds a green "Download All" button underneath the gremlin list in the downloader window! It downloads all gremlins that are not currently installed in the user's system. This implements the behavior requested by @Quicksilver151 in issue #52. 

### Main changes

I mainly worked with the AssetDownloaderGui class, the installation scripts themselves are unchanged. The most significant additions are:

- New "Download All" button (duh)
- New `download_queue` attribute that holds the list of gremlins to be downloaded
- New `active_worker` attribute that holds the DownloadWorker thread that is currently running
- New `_to_download_all_state` that displays a unique text and disables the list of characters underneath
- New `download_all` method that builds the queue, handles the confirmations, and starts the worker
- Rework of the worker.finished.connect callback. I replaced the `on_finished` method with 2 things:
  - `_handle_single_finished`: A simple method (similar to the original `on_finished`) that checks for success and refreshes the character list after every download.
  - `on_worker_finished`: Always calls the `_handle_single_finished` method first. Then, if there are still gremlins to download in the queue, starts the next download; else, clears the `active_worker` attribute and returns the window to the standby state.
  
### Observations

I did implement a check for when all the characters are already installed, which will show a simple message box to inform the user of this fact. However, maybe it would be good to also disable the green button (not just the gremlin list) to avoid misinput snafus...

Feel free to suggest any changes :)

Closes #52 