### PR TITLE
Added the window movement of gremlin running in niri compositor

### DIFF
--- a/src/window/gremlin_window.py
+++ b/src/window/gremlin_window.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import subprocess
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication, QLabel, QWidget
@@ -28,6 +30,10 @@ class GremlinWindow(QWidget):
         self.setWindowFlags(
             Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint
         )
+
+        # True if running under the niri compositor
+        self.is_niri = os.environ.get("NIRI_SOCKET") is not None
+
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
@@ -84,6 +90,22 @@ class GremlinWindow(QWidget):
         dx, dy = self.walk_manager.get_velocity()
         if dx != 0 or dy != 0:
             self.move(self.pos().x() + dx, self.pos().y() + dy)
+            if self.is_niri:
+                subprocess.run(
+                    [
+                        "niri",
+                        "msg",
+                        "action",
+                        "move-floating-window",
+                        "--x",
+                        str(self.pos().x() + dx),
+                        "--y",
+                        str(self.pos().y() + dy),
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
 
     def _on_exit(self) -> None:
         self.timer_manager.stop_all()


### PR DESCRIPTION
Adds support for moving the gremlin window when running under the niri Wayland compositor.

The gremlin's walking animation updates the window position using `QWidget.move()`. This works on X11/XWayland but does not reposition windows under native niri Wayland sessions.

Changes:
- Detect when the application is running under niri.
- Use `niri msg action move-floating-window` to update the floating window position.
- Keep the existing `QWidget.move()` behavior for all other environments, so there is no change for X11/XWayland users.

Tested on:
- niri (native Wayland): gremlin moves correctly.
- Existing behavior preserved for non-niri environments.